### PR TITLE
최초 로그인은 했지만 직업선택을 안한 유저 추가 처리 로직 

### DIFF
--- a/src/main/java/com/sirius/spurt/common/config/WebConfig.java
+++ b/src/main/java/com/sirius/spurt/common/config/WebConfig.java
@@ -3,6 +3,8 @@ package com.sirius.spurt.common.config;
 import com.sirius.spurt.common.resolver.LoginUserResolver;
 import com.sirius.spurt.common.resolver.NonLoginUserResolver;
 import com.sirius.spurt.store.provider.auth.AuthProvider;
+import com.sirius.spurt.store.provider.jobgroup.JobGroupProvider;
+import com.sirius.spurt.store.provider.user.UserProvider;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -13,10 +15,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
     private final AuthProvider authProvider;
+    private final UserProvider userProvider;
+    private final JobGroupProvider jobGroupProvider;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginUserResolver(authProvider));
+        resolvers.add(new LoginUserResolver(authProvider, userProvider, jobGroupProvider));
         resolvers.add(new NonLoginUserResolver(authProvider));
     }
 }

--- a/src/main/java/com/sirius/spurt/common/resolver/LoginUserResolver.java
+++ b/src/main/java/com/sirius/spurt/common/resolver/LoginUserResolver.java
@@ -1,10 +1,14 @@
 package com.sirius.spurt.common.resolver;
 
 import com.sirius.spurt.common.exception.GlobalException;
+import com.sirius.spurt.common.meta.JobGroup;
 import com.sirius.spurt.common.meta.ResultCode;
 import com.sirius.spurt.common.resolver.user.LoginUser;
 import com.sirius.spurt.store.provider.auth.AuthProvider;
 import com.sirius.spurt.store.provider.auth.vo.AuthVo;
+import com.sirius.spurt.store.provider.jobgroup.JobGroupProvider;
+import com.sirius.spurt.store.provider.user.UserProvider;
+import com.sirius.spurt.store.provider.user.vo.UserVo;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -17,6 +21,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class LoginUserResolver implements HandlerMethodArgumentResolver {
     private final AuthProvider authProvider;
+    private final UserProvider userProvider;
+    private final JobGroupProvider jobGroupProvider;
     private final String TOKEN_TYPE = "Bearer ";
 
     @Override
@@ -47,8 +53,14 @@ public class LoginUserResolver implements HandlerMethodArgumentResolver {
         if (StringUtils.hasLength(accessHeader) && accessHeader.startsWith(TOKEN_TYPE)) {
             String accessToken = accessHeader.replace(TOKEN_TYPE, "");
             userInfo = authProvider.getUserId(accessToken);
-        }
 
+            // 로그인 이후 직군 미선택 유저 추가 체크
+            UserVo userVo = userProvider.getUserInfo(userInfo.getUserId());
+            if (userVo == null) {
+                jobGroupProvider.saveJobGroup(
+                        userInfo.getUserId(), userInfo.getEmail(), JobGroup.DEVELOPER);
+            }
+        }
         return new LoginUser(userInfo.getUserId(), userInfo.getEmail());
     }
 }

--- a/src/test/java/com/sirius/spurt/BaseMvcTest.java
+++ b/src/test/java/com/sirius/spurt/BaseMvcTest.java
@@ -10,6 +10,8 @@ import com.sirius.spurt.custom.CustomRequestFieldSnippet;
 import com.sirius.spurt.custom.CustomResponseFieldSnippet;
 import com.sirius.spurt.store.provider.auth.AuthProvider;
 import com.sirius.spurt.store.provider.auth.vo.AuthVo;
+import com.sirius.spurt.store.provider.jobgroup.JobGroupProvider;
+import com.sirius.spurt.store.provider.user.UserProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -34,6 +36,8 @@ public class BaseMvcTest {
     @Autowired protected ObjectMapper objectMapper;
 
     @MockBean private AuthProvider authProvider;
+    @MockBean private UserProvider userProvider;
+    @MockBean private JobGroupProvider jobGroupProvider;
     protected MockMvc mockMvc;
 
     @BeforeEach


### PR DESCRIPTION
- 로그인은 했는데 최초에 직업선택을 안한경우 테이블에 회원가입이 안된다. 
- > 기본 api 통신로직에서 이런 유저는 한번 체크에서 우선 develop 직군으로 넣어주는로직 추가